### PR TITLE
[feat] Accesibility Added

### DIFF
--- a/iOS-Challenge/iOS-Challenge/Application/AppCoordinator.swift
+++ b/iOS-Challenge/iOS-Challenge/Application/AppCoordinator.swift
@@ -36,10 +36,15 @@ class AppCoordinator: CoordinatorProtocol {
         let homeView = makeHomeView()
         homeView.title = "HOME_TITLE".localized
         homeView.tabBarItem.image = UIImage(systemName: "house.fill")
+        /// Optional bonus: Accesibility on UIKit
+        homeView.tabBarItem.accessibilityLabel = "ACC_TAB_HOME_LABEL".localized
+        homeView.tabBarItem.accessibilityHint = "ACC_TAB_HOME_HINT".localized
 
         let favoritesView = makeFavoritesView()
         favoritesView.title = "FAVORITES_TITLE".localized
         favoritesView.tabBarItem.image = UIImage(systemName: "heart.fill")
+        favoritesView.tabBarItem.accessibilityLabel = "ACC_TAB_FAVORITES_LABEL".localized
+        favoritesView.tabBarItem.accessibilityHint = "ACC_TAB_FAVORITES_HINT".localized
 
         tabBarController.tabBar.tintColor = DesignSystem.Colors.tabBarSelectedUIColor
         tabBarController.tabBar.unselectedItemTintColor = DesignSystem.Colors.tabBarUnselectedUIColor

--- a/iOS-Challenge/iOS-Challenge/Resources/en.lproj/Localizable.strings
+++ b/iOS-Challenge/iOS-Challenge/Resources/en.lproj/Localizable.strings
@@ -64,3 +64,25 @@
 
 //Favorites View
 "NO_FAVORITES" = "No favorites";
+
+//Accesibility
+"ACC_TAB_HOME_LABEL" = "Home";
+"ACC_TAB_HOME_HINT" = "Access the main ads screen";
+"ACC_TAB_FAVORITES_LABEL" = "Favorites";
+"ACC_TAB_FAVORITES_HINT" = "Access the ads marked as favorites";
+"ACC_FAVORITE_ON_LABEL" = "Favorite activated";
+"ACC_FAVORITE_OFF_LABEL" = "Favorite deactivated";
+"ACC_FAVORITE_HINT" = "Tap to mark or unmark as favorite";
+"PRICE_PREFIX" = "Price:";
+"PHOTO_CAROUSEL_LABEL" = "Photo Carousel";
+"PHOTO_COUNT_FORMAT" = "Photo %d of %d";
+"PHOTO_CAROUSEL_HINT" = "Swipe left or right to change the photo";
+"ACC_MAP_LABEL" = "Location Map";
+"ACC_MAP_HINT" = "Tap to view the map in full screen";
+"ACC_DESCRIPTION_FORMAT" = "Description: %@";
+"ACC_SHOW_DESCRIPTION_HINT" = "Tap to listen to the full description";
+"ACC_HIDE_DESCRIPTION_HINT" = "Tap to hide the full description";
+"ACC_SHOW_DESCRIPTION_LABEL" = "Show full description";
+"ACC_HIDE_DESCRIPTION_LABEL" = "Hide full description";
+"ACC_DESCRIPTION_COLLAPSED" = "Collapsed description, tap to expand";
+

--- a/iOS-Challenge/iOS-Challenge/Resources/es.lproj/Localizable.strings
+++ b/iOS-Challenge/iOS-Challenge/Resources/es.lproj/Localizable.strings
@@ -65,3 +65,24 @@
 //Favorites View
 "NO_FAVORITES" = "No hay favoritos";
 
+//Accesibility
+"ACC_TAB_HOME_LABEL" = "Inicio";
+"ACC_TAB_HOME_HINT" = "Accede a la pantalla principal de anuncios";
+"ACC_TAB_FAVORITES_LABEL" = "Favoritos";
+"ACC_TAB_FAVORITES_HINT" = "Accede a los anuncios marcados como favoritos";
+"ACC_FAVORITE_ON_LABEL" = "Favorito activado";
+"ACC_FAVORITE_OFF_LABEL" = "Favorito desactivado";
+"ACC_FAVORITE_HINT" = "Pulse para marcar o desmarcar como favorito";
+"PRICE_PREFIX" = "Precio:";
+"PHOTO_CAROUSEL_LABEL" = "Carrusel de fotos";
+"PHOTO_COUNT_FORMAT" = "Foto %d de %d";
+"PHOTO_CAROUSEL_HINT" = "Desliza hacia la izquierda o derecha para cambiar de foto";
+"ACC_MAP_LABEL" = "Mapa de localización";
+"ACC_MAP_HINT" = "Pulse para ver el mapa en pantalla completa";
+"ACC_DESCRIPTION_FORMAT" = "Descripción: %@";
+"ACC_SHOW_DESCRIPTION_HINT" = "Pulse para escuchar la descripción completa";
+"ACC_HIDE_DESCRIPTION_HINT" = "Pulse para ocultar la descripción completa";
+"ACC_SHOW_DESCRIPTION_LABEL" = "Mostrar descripción completa";
+"ACC_HIDE_DESCRIPTION_LABEL" = "Ocultar descripción completa";
+"ACC_DESCRIPTION_COLLAPSED" = "Descripción resumida, pulse para expandir";
+

--- a/iOS-Challenge/iOS-Challenge/Resources/es.lproj/Localizable.strings
+++ b/iOS-Challenge/iOS-Challenge/Resources/es.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "BATHROOM" = "Baño";
 "ENERGY_CERTIFICATION" = "Certificado energético";
 "COMMUNAL_AREAS" = "Zonas comunes";
+"OK" = "OK"
 
 
 //PropertyCell

--- a/iOS-Challenge/iOS-Challenge/Screens/Common/Cells/PropertyCell.swift
+++ b/iOS-Challenge/iOS-Challenge/Screens/Common/Cells/PropertyCell.swift
@@ -52,6 +52,8 @@ struct PropertyCell: View {
                 }
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("\(property.address), \(property.municipality), \(property.province). " + "PRICE_PREFIX".localized + " \(property.formattedPrice)"))
     }
 
     @ViewBuilder
@@ -115,6 +117,10 @@ struct PropertyCell: View {
                         }
                     }
                     .padding([.bottom, .trailing], DesignSystem.Spacing.s)
+                /// Optional bonus: Accesibility on SwiftUI
+                    .accessibilityLabel(isFavorited ? "ACC_FAVORITE_ON_LABEL".localized :
+                        "ACC_FAVORITE_OFF_LABEL".localized)
+                    .accessibilityHint("ACC_FAVORITE_HINT".localized)
             }
             if let favoriteDate {
                 HStack {

--- a/iOS-Challenge/iOS-Challenge/Screens/DesignSystemComponents/SwipeImageGalley.swift
+++ b/iOS-Challenge/iOS-Challenge/Screens/DesignSystemComponents/SwipeImageGalley.swift
@@ -31,6 +31,10 @@ struct SwipeImageGalley: View {
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
         .frame(height: horizontalSizeClass == .regular ? nil : Constants.heightIphone)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("PHOTO_CAROUSEL_LABEL".localized))
+        .accessibilityValue(Text(String(format: "PHOTO_COUNT_FORMAT".localized, selectedImageIndex + 1, images.count)))
+        .accessibilityHint(Text("PHOTO_CAROUSEL_HINT".localized))
     }
 
     @ViewBuilder

--- a/iOS-Challenge/iOS-Challenge/Screens/DetailsView/PropertyDetails.swift
+++ b/iOS-Challenge/iOS-Challenge/Screens/DetailsView/PropertyDetails.swift
@@ -116,6 +116,9 @@ struct PropertyDetails: View {
                 .onTapGesture {
                     showMap = true
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text("ACC_MAP_LABEL".localized))
+                .accessibilityHint(Text("ACC_MAP_HINT".localized))
         }
         .navigationDestination(isPresented: $showMap) {
             MapView(latitude: property.ubication.latitude, longitude: property.ubication.longitude)
@@ -127,6 +130,11 @@ struct PropertyDetails: View {
             Text(property.propertyComment)
                 .bodyStyle
                 .lineLimit(commentExpanded ? nil : 5)
+                .accessibilityLabel(
+                    commentExpanded ?
+                    Text(property.propertyComment) :
+                    Text("ACC_DESCRIPTION_COLLAPSED".localized)
+                )
 
             Button(action: {
                 commentExpanded.toggle()
@@ -134,6 +142,9 @@ struct PropertyDetails: View {
                 Text(commentExpanded ? "VER_MENOS".localized : "VER_COMENTARIO_COMPLETO".localized)
                     .actionStyle
             }
+            .accessibilityLabel(commentExpanded ?
+                Text("ACC_HIDE_DESCRIPTION_LABEL".localized) :
+                Text("ACC_SHOW_DESCRIPTION_LABEL".localized))
         }
     }
 


### PR DESCRIPTION
Accesibility Added
before:


<img width="1053" alt="Captura de pantalla 2025-03-31 a las 7 05 27" src="https://github.com/user-attachments/assets/4f54f5af-4b7c-4fd8-9b67-90f22d9acfed" />
<img width="1052" alt="Captura de pantalla 2025-03-31 a las 6 56 53" src="https://github.com/user-attachments/assets/df8f3f53-6167-453f-8672-e5d346821224" />
<img width="1051" alt="Captura de pantalla 2025-03-31 a las 6 47 23" src="https://github.com/user-attachments/assets/1863c229-91ff-46af-ba44-ba8da351f33c" />
<img width="1053" alt="Captura de pantalla 2025-03-31 a las 6 46 48" src="https://github.com/user-attachments/assets/ea129f43-4155-41a5-a71e-6616059993f4" />
<img width="1056" alt="Captura de pantalla 2025-03-31 a las 6 45 16" src="https://github.com/user-attachments/assets/8f99bc56-3785-42cc-9f76-0d3a01cef5a6" />


Afert Accesibility:
<img width="1009" alt="Captura de pantalla 2025-03-31 a las 7 42 18" src="https://github.com/user-attachments/assets/73cd8191-88ea-4040-8fb6-8cc7c1f8e1a9" />
<img width="1012" alt="Captura de pantalla 2025-03-31 a las 7 41 58" src="https://github.com/user-attachments/assets/b9fb6c5d-285f-4ce3-b15d-5a7261dcfecc" />
<img width="960" alt="Captura de pantalla 2025-03-31 a las 7 40 00" src="https://github.com/user-attachments/assets/53ac8c1c-d8f4-4705-82f4-cdd7945bcc96" />

<img width="1010" alt="Captura de pantalla 2025-03-31 a las 7 42 43" src="https://github.com/user-attachments/assets/43650211-1cce-442d-8c10-284c93455b7c" />
<img width="1008" alt="Captura de pantalla 2025-03-31 a las 7 42 30" src="https://github.com/user-attachments/assets/53f40212-1d0c-4890-8c31-e17471248055" />


